### PR TITLE
Feature/commit hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm i -g @weareneopix/daily-log
 ```sh
 git-daliy-log [<range>] [<options>]
 ```
-###`<range>`
+#### `<range>`
 
 Show only commits in the specified revision range. When no `<range>` is specified, it defaults to HEAD
 (i.e. the whole history leading to the current commit). origin..HEAD specifies all the commits reachable from the current

--- a/README.md
+++ b/README.md
@@ -1,20 +1,52 @@
-# daily-log
-Generate a log based on the daily commits
+# Git Daily Log
+Generate a log based on the daily commits. The commit message format that is used and pares by `git-daily-log`
+is [Karma Semantic Commits](2)
 
-## Instalation
+## Installation
 
 Via npm:
 
-```
+```sh
 npm i -g @weareneopix/daily-log
 ```
+
+## Usage
+
+```sh
+git-daliy-log [<range>] [<options>]
+```
+###`<range>`
+
+Show only commits in the specified revision range. When no `<range>` is specified, it defaults to HEAD
+(i.e. the whole history leading to the current commit). origin..HEAD specifies all the commits reachable from the current
+commit (i.e. HEAD), but not from origin. For a complete list of ways to spell `<range>`, see the Specifying Ranges section of [gitrevisions](3).
 
 ## Options
 
 The CLI provides options to customize the output.
 
-| Option                  | Description                              | Required |
-|-------------------------|------------------------------------------|----------|
-| `-a, --author <author>` | Show only commits from provided `author` | No       |
-| `-m, --me`              | Show only my commits                     | No       |
-| `-h, --help`            | Get CLI usage information                | No       |
+| Option                  | Description                                                    | Required |
+|-------------------------|----------------------------------------------------------------|----------|
+| `-a, --author <author>` | Show only commits from provided `author`                       | No       |
+| `-s, --since <date>`    | Show commits more recent than a specific date. [More info.](1) | No       |
+| `-m, --me`              | Show only my commits                                           | No       |
+| `-h, --help`            | Get CLI usage information                                      | No       |
+
+## Examples
+Show all **your** commits since **yesterday**:
+
+```sh
+git-daily-log -m -s "1 day ago"
+# or
+git-daily-log --me --since "1 day ago"
+```
+
+Show all commits between two tags:
+
+```sh
+git-daily-log 1.3.0..1.2.1
+```
+
+[1]: https://git-scm.com/docs/git-log#Documentation/git-log.txt---sinceltdategt
+[2]: http://karma-runner.github.io/3.0/dev/git-commit-msg.html
+[3]: https://git-scm.com/docs/gitrevisions#_specifying_ranges

--- a/index.js
+++ b/index.js
@@ -1,132 +1,132 @@
 #!/usr/bin/env node
 
-const git = require('simple-git/promise')()
-const _ = require('lodash')
-const cp = require('copy-paste')
+const git = require('simple-git/promise')();
+const _ = require('lodash');
+const cp = require('copy-paste');
 const program = require('commander');
 const u = require('./utils');
 const m = require('./messages');
 
 const typeMap = {
-  'feat': 'New features',
-  'chore': 'Chores',
-  'refactor': 'Refactoring',
-  'fix': 'Fixes',
-  null: 'Other commits'
-}
+    'feat': 'New features',
+    'chore': 'Chores',
+    'refactor': 'Refactoring',
+    'fix': 'Fixes',
+    null: 'Other commits',
+};
 
 program
-  .option('-a, --author <author>', 'commit author')
-  .option('-c, --commit <commit>', 'commit hash')
-  .option('-s, --since <date>', 'show commits more recent than a specific date.')
-  .option('-m, --me', 'get only your commits')
-  .action(start);
+    .option('-a, --author <author>', 'commit author')
+    .option('-c, --commit <commit>', 'commit hash')
+    .option('-s, --since <date>', 'show commits more recent than a specific date.')
+    .option('-m, --me', 'get only your commits')
+    .action(start);
 
 program.parse(process.argv);
 
 async function getUsername() {
-  return git.raw(['config', '--get', 'user.name']);
+    return git.raw(['config', '--get', 'user.name']);
 }
 
 function tokenize(msg) {
-  const result = /^(\S+)\((.*)\):\s?(.*)/g.exec(msg)
-  if (result == null) return {type: null, scope: null, message: msg}
-  const [, type, scope, message] = result
-  return {type, scope, message}
+    const result = /^(\S+)\((.*)\):\s?(.*)/g.exec(msg);
+    if (result == null) return { type: null, scope: null, message: msg };
+    const [, type, scope, message] = result;
+    return { type, scope, message };
 }
 
 function scopeNameFormatter(scopeName) {
-  const name = scopeName == '*' ? 'general' : scopeName
-  return `> *${name}*`
+    const name = scopeName == '*' ? 'general' : scopeName;
+    return `> *${name}*`;
 }
 
 function scopeFormatter(scope) {
-  return _(scope)
-    .map((commits, scope) => {
-      const messages = commits.map(({message}) => `• ${message}`)
-      const formattedMsgs = messages.map(m => '> ' + m).join('\n')
-      if (scope != null && scope != 'null') { // lol
-        return `${scopeNameFormatter(scope)}\n${formattedMsgs}`
-      } else {
-        return formattedMsgs
-      }
-    })
+    return _(scope)
+        .map((commits, scope) => {
+            const messages = commits.map(({ message }) => `• ${message}`);
+            const formattedMsgs = messages.map(m => '> ' + m).join('\n');
+            if (scope != null && scope != 'null') { // lol
+                return `${scopeNameFormatter(scope)}\n${formattedMsgs}`;
+            } else {
+                return formattedMsgs;
+            }
+        });
 }
 
 function typeFormatter(group, type) {
-  const formattedType = typeMap[type] ? typeMap[type] : type
-  return `\`${formattedType}\`\n${group.join('\n>\n')}`
+    const formattedType = typeMap[type] ? typeMap[type] : type;
+    return `\`${formattedType}\`\n${group.join('\n>\n')}`;
 }
 
 async function getLog({ username, range, since }) {
-  try {
-    const log = await git.raw([
-      'log',
-      ...(range ? [`${range}`] : []),
-      ...(since ? [`--since="${since}"`] : []),
-      ...(username ? [`--author=${username}`] : []),
-      '--no-merges',
-      '--pretty=format:%s',
-    ])
+    try {
+        const log = await git.raw([
+            'log',
+            ...(range ? [`${range}`] : []),
+            ...(since ? [`--since="${since}"`] : []),
+            ...(username ? [`--author=${username}`] : []),
+            '--no-merges',
+            '--pretty=format:%s',
+        ]);
 
-    return log;
+        return log;
 
-  } catch (e) {
-    u.error(e);
-  }
+    } catch (e) {
+        u.error(e);
+    }
 }
 
 function prettyPrintLog(log) {
-  const messages = log.split('\n')
-  const print = _(messages)
-      .map(tokenize)
-      .groupBy('type')
-      .mapValues(x => _.groupBy(x, 'scope'))
-      .mapValues(scopeFormatter)
-      .map(typeFormatter)
-      .join('\n\n')
-  console.log(print)
-  return print;
+    const messages = log.split('\n');
+    const print = _(messages)
+        .map(tokenize)
+        .groupBy('type')
+        .mapValues(x => _.groupBy(x, 'scope'))
+        .mapValues(scopeFormatter)
+        .map(typeFormatter)
+        .join('\n\n');
+    console.log(print);
+    return print;
 }
 
 function copyLogToClipboard(log) {
-  try {
-    cp.copy(log);
-    u.success(m.success);
-    process.exit()
-  } catch (e) {
-    u.error(e);
-  }
+    try {
+        cp.copy(log);
+        u.success(m.success);
+        process.exit();
+    } catch (e) {
+        u.error(e);
+    }
 }
 
 async function start(r, o) {
-  /**
-   * Based on the number of parameters provided.
-   * Check what is an argument and what are options
-   */
-  let range;
-  let options = o;
-  if (typeof r === 'object') {
-    options = r;
-  } else {
-    range = r;
-  }
+    /**
+     * Based on the number of parameters provided.
+     * Check what is an argument and what are options
+     */
+    let range;
+    let options = o;
+    if (typeof r === 'object') {
+        options = r;
+    } else {
+        range = r;
+    }
 
-  let username = '';
-  const since = options.since;
+    let username = '';
+    const since = options.since;
 
-  if (options.author && options.me) u.error(m.selectedMandA);
-  if (options.author) username = options.author;
-  if (options.me) username = await getUsername();
+    if (options.author && options.me) u.error(m.selectedMandA);
+    if (options.author) username = options.author;
+    if (options.me) username = await getUsername();
 
-  username = username.trim();
-  let log = await getLog({ username, range, since });
+    username = username.trim();
+    let log = await getLog({ username, range, since });
 
-  if (!log) {
-    u.warning(m.blameItOnDgn);
-    process.exit()
-  }
+    if (!log) {
+        u.warning(m.blameItOnDgn);
+        process.exit();
+    }
 
-  log = prettyPrintLog(log);
-  copyLogToClipboard(log);
+    log = prettyPrintLog(log);
+    copyLogToClipboard(log);
 }

--- a/messages.js
+++ b/messages.js
@@ -1,5 +1,5 @@
 module.exports = {
     selectedMandA: `You can't use '-m' and '-a' at the same time`,
-    blameItOnDgn: `Looks like nothing has been done in last 16 hours.\nYou can probably blame it on design, though.`,
+    blameItOnDgn: `Looks like nothing has been done.\nYou can probably blame it on design, though.`,
     success: `\nSuccessfully copied to clipboard!`,
 }


### PR DESCRIPTION
Add an argument, `range`

### `<range>`

Show only commits in the specified revision range. When no `<range>` is specified, it defaults to HEAD
(i.e. the whole history leading to the current commit). origin..HEAD specifies all the commits reachable from the current
commit (i.e. HEAD), but not from origin. For a complete list of ways to spell `<range>`, see the Specifying Ranges section of [gitrevisions](3).

Add a new option, `since`:

| Option                  | Description                                                    | Required |
|-------------------------|----------------------------------------------------------------|----------|
| `-s, --since <date>`    | Show commits more recent than a specific date. [More info.](1) | No       |

[1]: https://git-scm.com/docs/git-log#Documentation/git-log.txt---sinceltdategt
[3]: https://git-scm.com/docs/gitrevisions#_specifying_ranges